### PR TITLE
Summary: Removes unused type that conflicts with HTTPoison.Base that is used above & fixes warning

### DIFF
--- a/lib/forcex/api/http.ex
+++ b/lib/forcex/api/http.ex
@@ -11,7 +11,6 @@ defmodule Forcex.Api.Http do
   @accept [{"Accept", "application/json"}]
   @accept_encoding [{"Accept-Encoding", "gzip,deflate"}]
 
-  @type method :: :get | :put | :post | :patch | :delete
   @type forcex_response :: map | {number, any} | String.t
 
   def raw_request(method, url, body, headers, options) do
@@ -26,11 +25,11 @@ defmodule Forcex.Api.Http do
   end
 
   @spec process_response(HTTPoison.Response.t) :: forcex_response
-  defp process_response(%HTTPoison.Response{body: body, headers: %{"Content-Encoding" => "gzip"} = headers} = resp) do
+  def process_response(%HTTPoison.Response{body: body, headers: %{"Content-Encoding" => "gzip"} = headers} = resp) do
     %{resp | body: :zlib.gunzip(body), headers: Map.drop(headers, ["Content-Encoding"])}
     |> process_response
   end
-  defp process_response(%HTTPoison.Response{body: body, headers: %{"Content-Encoding" => "deflate"} = headers} = resp) do
+  def process_response(%HTTPoison.Response{body: body, headers: %{"Content-Encoding" => "deflate"} = headers} = resp) do
     zstream = :zlib.open
     :ok = :zlib.inflateInit(zstream, -15)
     uncompressed_data = zstream |> :zlib.inflate(body) |> Enum.join
@@ -39,12 +38,12 @@ defmodule Forcex.Api.Http do
     %{resp | body: uncompressed_data, headers: Map.drop(headers, ["Content-Encoding"])}
     |> process_response
   end
-  defp process_response(%HTTPoison.Response{body: body, headers: %{"Content-Type" => "application/json" <> _} = headers} = resp) do
+  def process_response(%HTTPoison.Response{body: body, headers: %{"Content-Type" => "application/json" <> _} = headers} = resp) do
     %{resp | body: Poison.decode!(body, keys: :atoms), headers: Map.drop(headers, ["Content-Type"])}
     |> process_response
   end
-  defp process_response(%HTTPoison.Response{body: body, status_code: 200}), do: body
-  defp process_response(%HTTPoison.Response{body: body, status_code: status}), do: {status, body}
+  def process_response(%HTTPoison.Response{body: body, status_code: 200}), do: body
+  def process_response(%HTTPoison.Response{body: body, status_code: status}), do: {status, body}
 
   def process_request_headers(headers), do: headers ++ @user_agent ++ @accept ++ @accept_encoding
 


### PR DESCRIPTION
### Details
While attempting a minor upgrade of deps in project that uses this library a compile error was encounted that stated:

```
== Compilation error in file lib/forcex/api/http.ex ==
** (CompileError) lib/forcex/api/http.ex:14: type method/0 is already defined
```
It was discoved that the source of the conflict was the `use HTTPoison.Base` on line 8 in the same file. Removing line 14, it was unused anyway, resolves this compile error.

## Review Checklists
### Author
- [ ] Squashed & Rebased
- [ ] Commit message(s) conform to template (Summary, Details, Tracker)
- [ ] No browser warnings/errors
- [ ] Ran bin/qa

### Reviewer
- [ ] Readable
- [ ] Tests adequately cover implementation
- [ ] Backwards Compatible (Data, UI)
- [ ] No junk (Comments, Typos, Test Focus, Debug Statements)
- [ ] Components are divided well